### PR TITLE
fix(shard): name doesn't match dependency name

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,4 +1,4 @@
-name: crystal-web
+name: web
 version: 0.1.0
 license: MIT
 


### PR DESCRIPTION
Currently when you try to install the shard, shards complains about the name:

`Error shard name (crystal-web) doesn't match dependency name (web)`

This PR changes the shard name in shard.yml from `crystal-web` to `web` so it matches the dependency name!